### PR TITLE
Update abis.ts

### DIFF
--- a/ui/src/abis.ts
+++ b/ui/src/abis.ts
@@ -4,7 +4,7 @@ export { fetchNode, fetchNodeInfo, mintFunction, noteFunction } from "./helpers"
 
 export const API_PATH = "/explorer:kimap-explorer:doria.kino/api";
 
-export const KIMAP: `0x${string}` = "0xcA92476B2483aBD5D82AEBF0b56701Bb2e9be658";
+export const KIMAP: `0x${string}` = "0x000000000033e5CCbC52Ec7BDa87dB768f9aA93F";
 export const MULTICALL: `0x${string}` = "0xcA11bde05977b3631167028862bE2a173976CA11";
 export const KINO_ACCOUNT_IMPL: `0x${string}` = "0x38766C70a4FB2f23137D9251a1aA12b1143fC716";
 


### PR DESCRIPTION
When attempting to write a note or fact to Kimap, I get this error:

<img width="501" alt="Screenshot 2025-02-12 at 8 50 20 AM" src="https://github.com/user-attachments/assets/8766e1ff-9e4d-4784-a32b-1e9eabdd251f" />

I think this is purely a frontend bug, probably because the contract listed in abis.ts refers to the testnet implementation of Kimap. This PR replaces it with the correct one.

However, subname minting is likely still broken since the account implementation contract in abis.ts refers to the testnet version on a different network.